### PR TITLE
Boundary space pt stop mu foxtrot error

### DIFF
--- a/app/StopMu/StopMuFoxTrot.cxx
+++ b/app/StopMu/StopMuFoxTrot.cxx
@@ -1,6 +1,8 @@
 #include "StopMuFoxTrot.h"
 
+// larlite
 #include "LArUtil/LArProperties.h"
+#include "LArUtil/Geometry.h"
 
 #include "UBWireTool/UBWireTool.h"
 
@@ -21,6 +23,7 @@ namespace larlitecv {
 									     const std::vector<larcv::Image2D>& thrumu_v, const std::vector<BoundarySpacePoint>& startpts_v ) {
     std::vector< larlitecv::BMTrackCluster3D > track3d_v;
     const float cm_per_tick = larutil::LArProperties::GetME()->DriftVelocity()*0.5;
+    const float cm_per_wire = 0.3; // 0.3 cm per wire on each plane
 
     // incorporating tagged information
     // we mask out the charge information, but we also put that information
@@ -65,7 +68,50 @@ namespace larlitecv {
 	  std::cout << "row=-1 and dtick=" << fabs(3200.0+ft.back().pos()[0]/cm_per_tick-img_v.front().meta().max_y()) << std::endl;
 	  continue;
 	}
+	
       }
+
+      // Set this variable up here so that it is recognized when it is referenced.
+      bool pixel_outside_of_image = false;
+      
+      // correct the rounding error for the columns of the image.
+      // This is the analog of what is done above.
+      for (size_t p = 0; p < img_v.size(); p++) {
+	if (imgcoords[p+1] == -1) {
+
+	  // Make the value that you need to feed into the WireCoordinate function.
+	  Double_t xyz[3] = { ft.back().pos()[0], ft.back().pos()[1], ft.back().pos()[2] };
+	  // Convert the y and z coordinates into a wire on this plane.
+	  float wid = larutil::Geometry::GetME()->WireCoordinate( xyz, p );
+
+	  // The compression factor is 0 here and the minimum x value is 0, so you can just compare to the pixel width.
+	  if ( wid<img_v.front().meta().pixel_width() ) {
+
+	    std::cout << "Wire ID: " << wid << std::endl;
+	    std::cout << "Pixel Width: " << img_v.front().meta().pixel_width() << std::endl;
+	    
+	    imgcoords[p+1] = 0;
+	    std::vector<float> backend = ft.back().pos();
+	    backend[p] = img_v.front().meta().pos_x(p);
+	    std::vector<float> backdir = ft.back().dir();
+	    ft.pop_back();
+	    FoxStep fixedback( backend, backdir );
+	    ft.push_back( fixedback );
+
+	  }
+	  else {
+	    std::cout << "col=-1 and dwire=" << wid << std::endl;
+	    pixel_outside_of_image = true;
+
+	    break;
+	  }
+
+	}
+      }
+
+      // If the pixel is outside of the image, then continue.
+      // I do this here so that we do not interfere with that loop.
+      if (pixel_outside_of_image) continue;
       
       std::vector<BoundaryEndPt> bendpt_v;
       for ( int p=0; p<(int)img_v.size(); p++ ) {


### PR DESCRIPTION
I did the analogous thing that @twongjirad did but for the columns - this time, we check to make sure that the column pixel is less than 1 away from the origin in order to be rounded to 0.  Zero compression on this axis makes this easier.