### PR TITLE
Chris linker libraries error

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ CORE_SUBDIRS := Hashlib2plus Base
 #  CORE_SUBDIRS += CVUtil
 #endif
 
-APP_SUBDIRS := TaggerTypes Combinator GapChs UnipolarHack ChargeSegmentAlgos T3DMerge ThruMu StopMu UntaggedClustering SCE ContainedROI TaggerCROI
+APP_SUBDIRS := TaggerTypes Combinator GapChs UnipolarHack ChargeSegmentAlgos T3DMerge ThruMu StopMu UntaggedClustering SCE GeneralFlashMatchAlgo ContainedROI TaggerCROI
 
 .phony: all clean
 

--- a/app/GeneralFlashMatchAlgo/GeneralFlashMatchAlgo.cxx
+++ b/app/GeneralFlashMatchAlgo/GeneralFlashMatchAlgo.cxx
@@ -83,6 +83,33 @@ namespace larlitecv {
 
   }
 
+  // Declare a function that will store all of the flashes for an event in a running list rather than separating them according to their flash producer.
+  // This list assumes that there are two groups of flashes, one produced using 'simpleFlashBeam' and the second produced using 'simpleFlashCosmic', in that order.
+  // Input list: 'opflashes_v', which contains the sets of opflash products in different vectors within the entire vector, with each corresponding to a different flash producer.
+  std::vector< larlite::opflash* > GeneralFlashMatchAlgo::generate_single_opflash_vector_for_event( std::vector< larlite::event_opflash* > opflashes_v ) {
+
+    // Declare an output list of opflash products that will be filled with the information in the input vector, 'opflashes_v'.
+    std::vector< larlite::opflash* > single_opflash_vector;
+    single_opflash_vector.clear();
+
+    // Loop through the input vector and each vector within to generate 'single_opflash_vector' from its contents.
+    for ( size_t opflash_producer = 0; opflash_producer < opflashes_v.size(); ++opflash_producer ) {
+
+      // Loop through the inner vector of each 'event_opflash*> producer contained within 'opflashes_v' to fill the output 'single_opflash_vector'.
+      for ( size_t inner_opflash_iter = 0; inner_opflash_iter < opflashes_v.at( opflash_producer).size(); ++inner_opflash_iter ) {
+
+	// Append the opflash pointer located at this iteration in the inner loop over the 'opflashes_v' vector to the 'single_opflash_vector' output.
+	single_opflash_vector.push_back( opflashes_v.at( opflash_producer ).at( inner_opflash_iter ) );
+
+      }
+
+    }
+
+    // Return this single denomination flash list.
+    return single_opflash_vector;
+
+  }
+
   // A function that will generate tracks from the 'BMTrackCluster3D' objects that are formed from each pass of the tagger.
   // Inputs: trackcluster3d_v: A vector of 'BMTrackCluster3D' objects that were formed from a pass of the tagger.
   std::vector < larlite::track >  GeneralFlashMatchAlgo::generate_tracks_between_passes(const std::vector< larlitecv::BMTrackCluster3D > trackcluster3d_v) {

--- a/app/GeneralFlashMatchAlgo/GeneralFlashMatchAlgo.cxx
+++ b/app/GeneralFlashMatchAlgo/GeneralFlashMatchAlgo.cxx
@@ -96,10 +96,10 @@ namespace larlitecv {
     for ( size_t opflash_producer = 0; opflash_producer < opflashes_v.size(); ++opflash_producer ) {
 
       // Loop through the inner vector of each 'event_opflash*> producer contained within 'opflashes_v' to fill the output 'single_opflash_vector'.
-      for ( size_t inner_opflash_iter = 0; inner_opflash_iter < opflashes_v.at( opflash_producer).size(); ++inner_opflash_iter ) {
+      for ( size_t inner_opflash_iter = 0; inner_opflash_iter < opflashes_v.at( opflash_producer)->size(); ++inner_opflash_iter ) {
 
 	// Append the opflash pointer located at this iteration in the inner loop over the 'opflashes_v' vector to the 'single_opflash_vector' output.
-	single_opflash_vector.push_back( opflashes_v.at( opflash_producer ).at( inner_opflash_iter ) );
+	single_opflash_vector.push_back( &(opflashes_v.at( opflash_producer )->at( inner_opflash_iter )) );
 
       }
 

--- a/app/GeneralFlashMatchAlgo/GeneralFlashMatchAlgo.h
+++ b/app/GeneralFlashMatchAlgo/GeneralFlashMatchAlgo.h
@@ -46,6 +46,8 @@ namespace larlitecv {
 
     std::vector < larlite::track >  generate_tracks_between_passes( const std::vector< larlitecv::BMTrackCluster3D > trackcluster3d_v);
 
+    std::vector< larlite::opflash* > generate_single_opflash_vector_for_event( std::vector< larlite::event_opflash* > opflashes_v );
+
     void ExpandQClusterStartingWithLarliteTrack( flashana::QCluster_t qcluster, const larlite::track& larlite_track, double extension, bool extend_start, bool extend_end ); 
 
     bool isNearActiveVolumeEdge( ::geoalgo::Vector pt, double d );

--- a/app/TaggerCROI/GNUmakefile
+++ b/app/TaggerCROI/GNUmakefile
@@ -19,7 +19,8 @@ INCFLAGS += $(shell seltool-config --includes)
 #INCFLAGS += $(shell larcv-config --includes)/../app
 #INCFLAGS += $(shell larlite-config --includes)/../UserDev/BasicTool/GeoAlgo
 #INCFLAGS += $(shell larlite-config --includes)/../UserDev/BasicTool/FhiclLite
-INCFLAGS += $(shell larlitecv-config --includes)
+INCFLAGS += $(shell larlitecv-config --includes) 
+INCFLAGS += -I$(LARLITECV_BASEDIR)/app # Add this to obtain access to the 'GeneralFlashMatchAlgo' machinery.
 INCFLAGS += -I$(LARCV_BASEDIR)/app/ann_1.1.2/include
 INCFLAGS += -I$(LARLITE_BASEDIR)/../
 
@@ -32,6 +33,7 @@ include $(LARLITECV_BASEDIR)/Makefile/Makefile.${OSNAME}
 
 LDFLAGS += $(shell larcv-config --libs)
 LDFLAGS += $(shell larlite-config --libs) -lBasicTool_GeoAlgo
+LDFLAGS += $(shell larlitecv-config --libs) # Add this to include the analog of everything for larlitecv that is here for larlite/LArCV.
 # call the common GNUmakefile
 include $(LARLITECV_BASEDIR)/Makefile/GNUmakefile.CORE
 

--- a/app/TaggerCROI/TaggerCROIAlgo.cxx
+++ b/app/TaggerCROI/TaggerCROIAlgo.cxx
@@ -101,11 +101,17 @@ namespace larlitecv {
     }
     m_time_tracker[kThruMuBMT] += (std::clock()-timer)/(double)CLOCKS_PER_SEC;
 
+    // Because 'findImageTrackEnds' depends on 'flashMatchTrackEnds', use dummy vectors to use that function even though that part of the input is not necessary.
+    std::vector< int > necessary_for_compilation;
+    necessary_for_compilation.clear();
+    std::vector< int > idx_necessary_for_compilation;
+    idx_necessary_for_compilation.clear();
+
     // run flash tagger
     timer = std::clock();
-    anode_flash_tagger.flashMatchTrackEnds(   input.opflashes_v, input.img_v, input.badch_v, output.anode_spacepoint_v );
-    cathode_flash_tagger.flashMatchTrackEnds( input.opflashes_v, input.img_v, input.badch_v, output.cathode_spacepoint_v );
-    imgends_flash_tagger.findImageTrackEnds( input.img_v, input.badch_v, output.imgends_spacepoint_v );
+    anode_flash_tagger.flashMatchTrackEnds(   input.opflashes_v, input.img_v, input.badch_v, output.anode_spacepoint_v, output.anode_flash_idx_v, output.anode_flash_producer_idx_v );
+    cathode_flash_tagger.flashMatchTrackEnds( input.opflashes_v, input.img_v, input.badch_v, output.cathode_spacepoint_v, output.cathode_flash_idx_v, output.cathode_flash_producer_idx_v );
+    imgends_flash_tagger.findImageTrackEnds( input.img_v, input.badch_v, output.imgends_spacepoint_v, necessary_for_compilation, idx_necessary_for_compilation );
     int totalflashes = (int)output.anode_spacepoint_v.size() + (int)output.cathode_spacepoint_v.size() + (int)output.imgends_spacepoint_v.size();
     if ( m_config.verbosity>0 ) {
       std::cout << " Flash Tagger End Points: " << totalflashes << std::endl;
@@ -124,38 +130,95 @@ namespace larlitecv {
     // we collect pointers to all the end points
     std::vector< const larlitecv::BoundarySpacePoint* > all_endpoints;
 
+    // For the rest of this function, I will declare the flash index vector with the same name as the current vector of the boundary spacepoints.
+
+    // Declare a vector of flash indices, corresponding to the flash index that this flash was matched to in 'FlashMuonTaggerAlgo' if it is anode-piercing or cathode-piercing.
+    // This will be the same dimension as 'all_endpoints'.  Endpoints that are not anode-piercing/cathode-piercing will have a value of -1 in this array.
+    std::vector< int > all_endpoints_flash_idx_v;
+    all_endpoints_flash_idx_v.clear();
+
+    // Declare a vector of flash producer indices, corresponding to the producer that the flash was generated with.
+    // The scoring sceme is as follows:
+    // '0': simpleFlashBeam.                                                                                                                                                                            
+    // '1': simpleFlashCosmic                                                                                                                                                                            
+    // '-1': endpoint was not determined from a flash.                                                                                                                                                  
+    // All flash producer indices corresponding to a side-piercing endpoint will be filled with -1.
+    std::vector< int > all_endpoints_flash_producer_idx_v;
+    all_endpoints_flash_producer_idx_v.clear();
+    
     // gather endpoints from space points
     for (int isp=0; isp<(int)output.side_spacepoint_v.size(); isp++) {
       const larlitecv::BoundarySpacePoint* pts = &(output.side_spacepoint_v.at( isp ));
       all_endpoints.push_back( pts );
+      all_endpoints_flash_idx_v.push_back( -1 );
+      all_endpoints_flash_producer_idx_v.push_back( -1 );
     }
     for (int isp=0; isp<(int)output.anode_spacepoint_v.size(); isp++) {
       const larlitecv::BoundarySpacePoint* pts = &(output.anode_spacepoint_v.at(isp));
       all_endpoints.push_back( pts );
+      all_endpoints_flash_idx_v.push_back( output.anode_flash_idx_v.at( isp ) );
+      all_endpoints_flash_producer_idx_v.push_back( output.anode_flash_producer_idx_v.at( isp ) );
     }
     for (int isp=0; isp<(int)output.cathode_spacepoint_v.size(); isp++) {
       const larlitecv::BoundarySpacePoint* pts = &(output.cathode_spacepoint_v.at(isp));
       all_endpoints.push_back( pts );
+      all_endpoints_flash_idx_v.push_back( output.cathode_flash_idx_v.at( isp ) );
+      all_endpoints_flash_producer_idx_v.push_back( output.cathode_flash_producer_idx_v.at( isp ) );
     }
     for (int isp=0; isp<(int)output.imgends_spacepoint_v.size(); isp++) {
       const larlitecv::BoundarySpacePoint* pts = &(output.imgends_spacepoint_v.at(isp));
       all_endpoints.push_back( pts );
+      all_endpoints_flash_idx_v.push_back( -1 );
+      all_endpoints_flash_producer_idx_v.push_back( -1 );
     }
     if ( m_config.verbosity>0 )
       std::cout << "number of endpoints pre-filters: " << all_endpoints.size() << std::endl;
 
     // first filter: radialfilter
     std::vector< const larlitecv::BoundarySpacePoint* > pass_radial_filter;
+
+    // Declare a vector of the indices of the flash endpoints that pass the radial filter here.
+    std::vector< int > pass_radial_filter_flash_idx_v;
+    pass_radial_filter_flash_idx_v.clear();
+
+    // Declare a corresponding vector of the flash producer indices of the flash endpoints that pass the radial filter here.
+    std::vector< int > pass_radial_filter_flash_producer_idx_v;
+    pass_radial_filter_flash_producer_idx_v.clear();
+
+    // Declare an iterator to keep track of which endpoint we are iterating over.
+    int all_endpoint_iter = 0;
+    
     for ( auto const& psp : all_endpoints ) {
       bool forms_segment = radialfilter.canFormSegment( (*psp).pos(), input.img_v, input.badch_v, 5.0, m_config.thrumu_tracker_cfg.pixel_threshold, 1, 2, 0.5, false ); // need parameters here
-      if ( forms_segment )
+      if ( forms_segment ) {
         pass_radial_filter.push_back( psp );
+	pass_radial_filter_flash_idx_v.push_back( all_endpoints_flash_idx_v.at( all_endpoint_iter ) );
+	pass_radial_filter_flash_producer_idx_v.push_back( all_endpoints_flash_producer_idx_v.at( all_endpoint_iter ) );
+      }
+
+      // Increment 'all_endpoint_iter'.
+      ++all_endpoint_iter;
     }
+					       
     if ( m_config.verbosity>0 )
       std::cout << "number of endpoints post-radial filter: " << pass_radial_filter.size() << std::endl;
 
     // then we push the end points out
     std::vector< larlitecv::BoundarySpacePoint > pushed_endpoints;
+    
+    // Declare a vector of the indices of the flash endpoints that are pushed.
+    // This should not eliminate any endpoints, but this is a measure of caution.
+    std::vector< int > pushed_endpoints_flash_idx_v;
+    pushed_endpoints_flash_idx_v.clear();
+
+    // Declare a vector of the flash producer indices of the flash endpoints that are pushed.
+    // This should not eliminate any endpoints, but this is a measure of caution.
+    std::vector< int > pushed_endpoints_flash_producer_idx_v;
+    pushed_endpoints_flash_producer_idx_v.clear();
+
+    // Declare an iterator to keep track of which iterator we are looping over.
+    int pass_radial_filter_iter = 0;
+  
     for ( auto const& psp : pass_radial_filter ) {
       const larlitecv::BoundarySpacePoint& sp = (*psp);
       if ( psp==NULL || sp.size()!=3 ) {
@@ -195,10 +258,18 @@ namespace larlitecv {
                   << " closer2wall=" << closer2wall << std::endl;
       }
 
-      if ( closer2wall  )
+      if ( closer2wall  ) {
         pushed_endpoints.push_back( pushed );
-      else
+	pushed_endpoints_flash_idx_v.push_back( pass_radial_filter_flash_idx_v.at( pass_radial_filter_iter ) );
+	pushed_endpoints_flash_producer_idx_v.push_back( pass_radial_filter_flash_producer_idx_v.at( pass_radial_filter_iter ) );
+      }
+      else {
         pushed_endpoints.push_back( sp );
+	pushed_endpoints_flash_idx_v.push_back( pass_radial_filter_flash_idx_v.at( pass_radial_filter_iter ) );
+	pushed_endpoints_flash_producer_idx_v.push_back( pass_radial_filter_flash_producer_idx_v.at( pass_radial_filter_iter ) );
+      }
+      // Increment 'pass_radial_filter_iter'.
+      ++pass_radial_filter_iter;
     }
 
     std::vector< const larlitecv::BoundarySpacePoint* > pushed_ptr_endpoints;
@@ -229,6 +300,9 @@ namespace larlitecv {
     endptfilter.removeBoundaryAndFlashDuplicates( pushed_ptr_endpoints, input.img_v, input.gapch_v, endpoint_passes );
     endptfilter.removeSameBoundaryDuplicates( pushed_ptr_endpoints, input.img_v, input.gapch_v, endpoint_passes );
 
+   // Within this loop, append entries to all of the 'anode_filtered_flash_idx_v', 'cathode_filtered_flash_idx_v', 'all_filtered_flash_idx_v', 'anode_filtered_flash_producer_idx_v', 'cathode_filtered_flash_producer_idx_v', and 'all_filtered_flash_producer_idx_v' from
+    // 'pushed_endpoints_flash_idx_v'.  
+    
     // remove the filtered end points
     for ( size_t idx=0; idx<endpoint_passes.size(); idx++ ) {
       larlitecv::BoundarySpacePoint& sp = pushed_endpoints[idx];
@@ -236,12 +310,28 @@ namespace larlitecv {
       if ( endpoint_passes.at(idx)==1 ) {
         if (sp.type()<=larlitecv::kDownstream ) {
           output.side_filtered_v.emplace_back( std::move(sp) );
+
+	  // These additions to 'output.all_filtered_flash_idx_v' and 'output.all_filtered_flash_producer_idx_v' will consist entirely of -1s.
+	  output.all_filtered_flash_idx_v.push_back( pushed_endpoints_flash_idx_v.at( idx ) );
+	  output.all_filtered_flash_producer_idx_v.push_back( pushed_endpoints_flash_producer_idx_v.at( idx ) );
         }
         else if (sp.type()==larlitecv::kAnode) {
           output.anode_filtered_v.emplace_back( std::move(sp) );
+
+	  // These additions will consist of actual flashes.
+	  output.anode_filtered_flash_idx_v.push_back( pushed_endpoints_flash_idx_v.at( idx ) );
+	  output.all_filtered_flash_idx_v.push_back( pushed_endpoints_flash_idx_v.at( idx ) );
+	  output.anode_filtered_flash_producer_idx_v.push_back( pushed_endpoints_flash_producer_idx_v.at( idx ) );
+          output.all_filtered_flash_producer_idx_v.push_back( pushed_endpoints_flash_producer_idx_v.at( idx ) );
         }
         else if (sp.type()==larlitecv::kCathode) {
           output.cathode_filtered_v.emplace_back( std::move(sp) );
+
+	  // These additions will consist of actual flashes matched to cathode-piercing tracks.                                                                                                      
+          output.cathode_filtered_flash_idx_v.push_back( pushed_endpoints_flash_idx_v.at( idx ) );
+          output.all_filtered_flash_idx_v.push_back( pushed_endpoints_flash_idx_v.at( idx ) );
+	  output.cathode_filtered_flash_producer_idx_v.push_back( pushed_endpoints_flash_producer_idx_v.at( idx ) );
+          output.all_filtered_flash_producer_idx_v.push_back( pushed_endpoints_flash_producer_idx_v.at( idx ) );
         }
         else if (sp.type()==larlitecv::kImageEnd) {
           output.imgends_filtered_v.emplace_back( std::move(sp) );
@@ -282,22 +372,44 @@ namespace larlitecv {
     // we collect pointers to all the end points
     std::vector< const larlitecv::BoundarySpacePoint* > all_endpoints;
 
+    // Collect the indices for the flash that determines each of the endpoints and the index for the producer that makes each of the endpoints as well.
+    // This is a precaution to ensure that we are collecting this information properly.
+    std::vector< int > all_endpoints_flash_idx_v;
+    all_endpoints_flash_idx_v.clear();
+
+    std::vector< int > all_endpoints_flash_producer_idx_v;
+    all_endpoints_flash_producer_idx_v.clear();
+
+    // When filling the 'all_endpoints_flash_idx_v' and 'all_endpoints_flash_producer_idx_v', the correct flash indices have already been matched to the correct endpoint.  The important thing is that these two vectors are filled at the same point as their corresponding endpoint in 'all_endpoints'.
+
     // gather endpoints from space points
     for (int isp=0; isp<(int)output.side_filtered_v.size(); isp++) {
       const larlitecv::BoundarySpacePoint* pts = &(output.side_filtered_v.at( isp ));
       all_endpoints.push_back( pts );
+      // Fill the vectors 'all_endpoints_flash_idx_v' and 'all_endpoints_flash_producer_idx_v' with a -1 at the index corresponding to this endpoint. None of these tracks correspond to a flash.
+      all_endpoints_flash_idx_v.push_back( -1 );
+      all_endpoints_flash_producer_idx_v.push_back( -1 );
     }
     for (int isp=0; isp<(int)output.anode_filtered_v.size(); isp++) {
       const larlitecv::BoundarySpacePoint* pts = &(output.anode_filtered_v.at(isp));
       all_endpoints.push_back( pts );
+      // Fill the vectors 'all_endpoints_flash_idx_v' and 'all_endpoints_flash_producer_idx_v' with the corresponding values in the 'anode_filtered_flash_idx_v' and 'anode_filtered_flash_producer_idx_v'.
+      all_endpoints_flash_idx_v.push_back( output.anode_filtered_flash_idx_v.at( isp ) );
+      all_endpoints_flash_producer_idx_v.push_back( output.anode_filtered_flash_producer_idx_v.at( isp ) );
     }
     for (int isp=0; isp<(int)output.cathode_filtered_v.size(); isp++) {
       const larlitecv::BoundarySpacePoint* pts = &(output.cathode_filtered_v.at(isp));
       all_endpoints.push_back( pts );
+      // Fill the vectors 'all_endpoints_flash_idx_v' and 'all_endpoints_flash_producer_idx_v' with the corresponding values in the 'cathode_filtered_flash_idx_v' and 'cathode_filtered_flash_producer_idx_v'.
+      all_endpoints_flash_idx_v.push_back( output.cathode_filtered_flash_idx_v.at( isp ) );
+      all_endpoints_flash_producer_idx_v.push_back( output.cathode_filtered_flash_producer_idx_v.at( isp ) );
     }
     for (int isp=0; isp<(int)output.imgends_filtered_v.size(); isp++) {
       const larlitecv::BoundarySpacePoint* pts = &(output.imgends_filtered_v.at(isp));
       all_endpoints.push_back( pts );
+      // Fill the vectors 'all_endpoints_flash_idx_v' and 'all_endpoints_flash_producer_idx_v' with a -1 at the index corresponding to this endpoint.
+      all_endpoints_flash_idx_v.push_back( -1 );
+      all_endpoints_flash_producer_idx_v.push_back( -1 );
     }
     if ( m_config.verbosity>0 )
       std::cout << "number of endpoints to search for thrumu: " << all_endpoints.size() << std::endl;
@@ -308,7 +420,8 @@ namespace larlitecv {
       timer = std::clock();
       output.trackcluster3d_v.clear();
       output.tagged_v.clear();
-      thrumu_tracker.makeTrackClusters3D( input.img_v, input.gapch_v, all_endpoints, output.trackcluster3d_v, output.tagged_v, used_endpoints );
+      // Use the 'makeTrackClusters3D' function; the crucial point here is that the flash information stored in the last two arguments of this function, 'all_endpoints_flash_idx_v' and 'all_endpoints_flash_producer_idx_v', correspond to the endpoints in the 'all_endpoints' vector (the third argument).
+      thrumu_tracker.makeTrackClusters3D( m_config.general_flash_match_cfg, input.img_v, input.gapch_v, all_endpoints, output.trackcluster3d_v, output.tagged_v, used_endpoints, input.opflashes_v, all_endpoints_flash_idx_v, all_endpoints_flash_producer_idx_v);
       m_time_tracker[kThruMuTracker]  +=  (std::clock()-timer)/(double)CLOCKS_PER_SEC;
       if ( m_config.verbosity>0 )
         std::cout << "thrumu tracker search " << all_endpoints.size() << " end points in " << m_time_tracker[kThruMuTracker] << " sec" << std::endl;

--- a/app/TaggerCROI/TaggerCROIAlgoConfig.cxx
+++ b/app/TaggerCROI/TaggerCROIAlgoConfig.cxx
@@ -22,30 +22,32 @@ namespace larlitecv {
 
     TaggerCROIAlgoConfig cfg;
 
-    larcv::PSet root_pset           = larcv::CreatePSetFromFile( filepath );
-    larcv::PSet tagger_pset         = root_pset.get<larcv::PSet>("TaggerCROI");
-    larcv::PSet sidetagger_pset     = tagger_pset.get<larcv::PSet>("BMTSideTagger");
-    larcv::PSet flashtagger_pset    = tagger_pset.get<larcv::PSet>("BMTFlashTagger");
-    larcv::PSet thrumu_tracker_pset = tagger_pset.get<larcv::PSet>("ThruMuTracker");
-    larcv::PSet stopmu_filter_pset  = tagger_pset.get<larcv::PSet>("StopMuSpacePointsFilter");
-    larcv::PSet stopmu_cluster_pset = tagger_pset.get<larcv::PSet>("StopMuCluster");
-    larcv::PSet stopmu_foxtrot_pset = tagger_pset.get<larcv::PSet>("StopMuFoxTrot");
-    larcv::PSet untagged_cluster_ps = tagger_pset.get<larcv::PSet>("ContainedGroupAlgo");
-    larcv::PSet untagged_match_pset = tagger_pset.get<larcv::PSet>("TaggerFlashMatchAlgo");
+    larcv::PSet root_pset                = larcv::CreatePSetFromFile( filepath );
+    larcv::PSet tagger_pset              = root_pset.get<larcv::PSet>("TaggerCROI");
+    larcv::PSet sidetagger_pset          = tagger_pset.get<larcv::PSet>("BMTSideTagger");
+    larcv::PSet flashtagger_pset         = tagger_pset.get<larcv::PSet>("BMTFlashTagger");
+    larcv::PSet thrumu_tracker_pset      = tagger_pset.get<larcv::PSet>("ThruMuTracker");
+    larcv::PSet stopmu_filter_pset       = tagger_pset.get<larcv::PSet>("StopMuSpacePointsFilter");
+    larcv::PSet stopmu_cluster_pset      = tagger_pset.get<larcv::PSet>("StopMuCluster");
+    larcv::PSet stopmu_foxtrot_pset      = tagger_pset.get<larcv::PSet>("StopMuFoxTrot");
+    larcv::PSet untagged_cluster_ps      = tagger_pset.get<larcv::PSet>("ContainedGroupAlgo");
+    larcv::PSet untagged_match_pset      = tagger_pset.get<larcv::PSet>("TaggerFlashMatchAlgo");
+    larcv::PSet general_flash_match_pset = tagger_pset.get<larcv::PSet>("GeneralFlashMatchAlgo"); // new for the general flash matching occurring between the tracks and the flashes of light.
 
     cfg.input_write_cfg  = tagger_pset.get<larcv::PSet>("InputWriteConfig");
     cfg.thrumu_write_cfg = tagger_pset.get<larcv::PSet>("ThruMuWriteConfig");
     cfg.stopmu_write_cfg = tagger_pset.get<larcv::PSet>("StopMuWriteConfig");
     cfg.croi_write_cfg   = tagger_pset.get<larcv::PSet>("CROIWriteConfig");
 
-    cfg.sidetagger_cfg       = larlitecv::MakeBoundaryMuonTaggerAlgoConfigFromPSet( sidetagger_pset );
-    cfg.flashtagger_cfg      = larlitecv::MakeFlashMuonTaggerAlgoConfigFromPSet( flashtagger_pset );
-    cfg.thrumu_tracker_cfg   = larlitecv::ThruMuTrackerConfig::MakeFromPSet( thrumu_tracker_pset );
-    cfg.stopmu_filterpts_cfg = larlitecv::MakeStopMuFilterSpacePointsConfigFromPSet( stopmu_filter_pset );
-    cfg.stopmu_cluster_cfg   = larlitecv::makeStopMuClusterConfigFromPSet( stopmu_cluster_pset );
-    cfg.stopmu_foxtrot_cfg   = larlitecv::StopMuFoxTrotConfig::makeFromPSet( stopmu_foxtrot_pset );
-    cfg.untagged_cluster_cfg = larlitecv::ClusterGroupAlgoConfig::MakeClusterGroupAlgoConfigFromPSet( untagged_cluster_ps );
-    cfg.croi_selection_cfg   = larlitecv::TaggerFlashMatchAlgoConfig::MakeTaggerFlashMatchAlgoConfigFromPSet( untagged_match_pset );
+    cfg.sidetagger_cfg          = larlitecv::MakeBoundaryMuonTaggerAlgoConfigFromPSet( sidetagger_pset );
+    cfg.flashtagger_cfg         = larlitecv::MakeFlashMuonTaggerAlgoConfigFromPSet( flashtagger_pset );
+    cfg.thrumu_tracker_cfg      = larlitecv::ThruMuTrackerConfig::MakeFromPSet( thrumu_tracker_pset );
+    cfg.stopmu_filterpts_cfg    = larlitecv::MakeStopMuFilterSpacePointsConfigFromPSet( stopmu_filter_pset );
+    cfg.stopmu_cluster_cfg      = larlitecv::makeStopMuClusterConfigFromPSet( stopmu_cluster_pset );
+    cfg.stopmu_foxtrot_cfg      = larlitecv::StopMuFoxTrotConfig::makeFromPSet( stopmu_foxtrot_pset );
+    cfg.untagged_cluster_cfg    = larlitecv::ClusterGroupAlgoConfig::MakeClusterGroupAlgoConfigFromPSet( untagged_cluster_ps );
+    cfg.croi_selection_cfg      = larlitecv::TaggerFlashMatchAlgoConfig::MakeTaggerFlashMatchAlgoConfigFromPSet( untagged_match_pset );
+    cfg.general_flash_match_cfg = larlitecv::GeneralFlashMatchAlgoConfig::MakeConfigFromPSet( general_flash_match_pset );
 
     // run controls
     cfg.run_thrumu_tracker      = tagger_pset.get<bool>("RunThruMuTracker",true);

--- a/app/TaggerCROI/TaggerCROIAlgoConfig.h
+++ b/app/TaggerCROI/TaggerCROIAlgoConfig.h
@@ -13,6 +13,7 @@
 #include "StopMu/StopMuFoxTrotConfig.h"
 #include "UntaggedClustering/ClusterGroupAlgo.h"
 #include "ContainedROI/TaggerFlashMatchAlgoConfig.h"
+#include "GeneralFlashMatchAlgo/GeneralFlashMatchAlgoConfig.h"
 
 namespace larlitecv {
 
@@ -29,6 +30,7 @@ namespace larlitecv {
     StopMuFoxTrotConfig           stopmu_foxtrot_cfg;
     ClusterGroupAlgoConfig        untagged_cluster_cfg;
     TaggerFlashMatchAlgoConfig    croi_selection_cfg;
+    GeneralFlashMatchAlgoConfig   general_flash_match_cfg;
 
     larcv::PSet input_write_cfg;
     larcv::PSet thrumu_write_cfg;

--- a/app/TaggerCROI/TaggerCROITypes.h
+++ b/app/TaggerCROI/TaggerCROITypes.h
@@ -66,10 +66,37 @@ namespace larlitecv {
     std::vector< BoundarySpacePoint > cathode_spacepoint_v;
     std::vector< BoundarySpacePoint > imgends_spacepoint_v;
 
+    // New info for the flash indices of the anode/cathode tracks.
+    std::vector < int >               anode_flash_idx_v;
+    std::vector < int >               cathode_flash_idx_v;
+
+    // New info for the flash producer indices corresponding to the flashes that are listed in the 'filtered' vectors shown above.
+    // '0': simpleFlashBeam.
+    // '1': simpleFlashCosmic
+    // '-1': endpoint was not determined from a flash.
+    // All flash producer indices corresponding to a side-piercing endpoint will be filled with -1. 
+    std::vector < int >               anode_flash_producer_idx_v;
+    std::vector < int >               cathode_flash_producer_idx_v;
+    
     std::vector< BoundarySpacePoint > side_filtered_v;
     std::vector< BoundarySpacePoint > anode_filtered_v;
     std::vector< BoundarySpacePoint > cathode_filtered_v;
     std::vector< BoundarySpacePoint > imgends_filtered_v;
+
+    // New info for the filtered flash indices of the anode/cathode tracks and ALL Tracks (for consistency).
+    // All flash indices corresponding to a side endpoint are set to -1.
+    std::vector< int > anode_filtered_flash_idx_v;
+    std::vector< int > cathode_filtered_flash_idx_v;
+    std::vector< int > all_filtered_flash_idx_v;
+
+    // New info for the flash producer indices corresponding to the flashes that are listed in the 'filtered' vectors shown above.
+    // '0': simpleFlashBeam.
+    // '1': simpleFlashCosmic
+    // '-1': endpoint was not determined from a flash.
+    // All flash producer indices corresponding to a side-piercing endpoint will be filled with -1.
+    std::vector< int > anode_filtered_flash_producer_idx_v;
+    std::vector< int > cathode_filtered_flash_producer_idx_v;
+    std::vector< int > all_filtered_flash_producer_idx_v;
     
     std::vector< BMTrackCluster3D >      trackcluster3d_v;
     std::vector< larlite::track >        track_v;
@@ -99,10 +126,28 @@ namespace larlitecv {
       cathode_spacepoint_v.clear();
       imgends_spacepoint_v.clear();
 
+      // Also clear the flash indices of anode/cathode piercing tracks.         
+      anode_flash_idx_v.clear();
+      cathode_flash_idx_v.clear();
+
+      // Also clear the flash indices of the producers of anode/cathode piercing tracks.
+      anode_flash_producer_idx_v.clear();
+      cathode_flash_producer_idx_v.clear();
+
       side_filtered_v.clear();
       anode_filtered_v.clear();
       cathode_filtered_v.clear();
       imgends_filtered_v.clear();
+
+      // Also clear the flash indices of the filtered anode/cathode piercing tracks.
+      anode_filtered_flash_idx_v.clear();
+      cathode_filtered_flash_idx_v.clear();
+      all_filtered_flash_idx_v.clear();
+
+      // Also clear the indices of the flash producers of the filtered anode/cathode-piercing tracks.
+      anode_filtered_flash_producer_idx_v.clear();
+      cathode_filtered_flash_producer_idx_v.clear();
+      all_filtered_flash_producer_idx_v.clear();
       
       trackcluster3d_v.clear();
       track_v.clear();

--- a/app/TaggerCROI/bin/GNUmakefile
+++ b/app/TaggerCROI/bin/GNUmakefile
@@ -10,8 +10,10 @@ CXXFLAGS += $(shell larcv-config --includes)
 CXXFLAGS += $(shell larcv-config --includes)/../app
 CXXFLAGS += $(shell larlitecv-config --includes)
 CXXFLAGS += $(shell larlitecv-config --includes)/../app
+CXXFLAGS += -I$(LARLITECV_BASEDIR)/app # Add this so that 'GeneralFlashMatchAlgo/GeneralFlashMatchAlgoConfig.h'.                                                                           
 #CXXFLAGS += -I$(KALMAN_INCDIR)
 CXXFLAGS += -I$(LARCV_BASEDIR)/app/ann_1.1.2/include
+
 ifeq ($(LARCV_OPENCV),1)
 CXXFLAGS += -I$(OPENCV_INCDIR) -DUSE_OPENCV
 endif

--- a/app/TaggerCROI/bin/run_tagger.cxx
+++ b/app/TaggerCROI/bin/run_tagger.cxx
@@ -23,6 +23,7 @@
 #include "TaggerCROI/TaggerCROIAlgo.h"
 #include "TaggerCROI/TaggerCROITypes.h"
 #include "TaggerCROI/PayloadWriteMethods.h"
+#include "GeneralFlashMatchAlgo/GeneralFlashMatchAlgo.h"
 
 int main(int nargs, char** argv ) {
 

--- a/app/TaggerCROI/bin/tagger.cfg
+++ b/app/TaggerCROI/bin/tagger.cfg
@@ -159,6 +159,7 @@ TaggerCROI: {
     PixelThresholds: [10.0, 10.0, 10.0]
     CompressionMode: 2
     DownsampleFactor: 4
+    ThruMuFlashMatch: true
     ThruMuPassConfig0: {
       RunRadialFilter: false
       RunLinearTagger: true
@@ -590,4 +591,57 @@ TaggerCROI: {
     }
   }
 
+# Add the configuration parameters for the new 'GeneralFlashMatchAlgo' class here.
+# Most of the parameters in this section are redundant from the last section - that will be fixed when this flash-matching infrastructure is used in the entire tagger.
+ GeneralFlashMatchAlgo: {
+    Verbosity: 2
+    QClusterStepSize: 0.3
+    MeV_per_cm: 2.3
+    FudgeFactor: 33333.0
+    CosmicDiscFudgeFactor: 16666.5
+    PMTFlashThreshold: 3.0
+    UseGaus2D: false
+    FlashMatchManager: {
+      Verbosity: 2
+      AllowReuseFlash: true
+      StoreFullResult: true
+      FlashFilterAlgo: ""
+      TPCFilterAlgo: ""
+      ProhibitAlgo: ""
+      HypothesisAlgo: "PhotonLibHypothesis"
+      MatchAlgo: "QLLMatch"
+      CustomAlgo: []
+    }
+  QLLMatch: {
+     Verbosity: 0
+     RecordHistory: false
+     NormalizeHypothesis: false
+     QLLMode: 0 # 0 for Chi2, 1 for LLHD                                                                                                                                                                   
+     PEPenaltyThreshold: [6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6]
+     PEPenaltyValue: [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
+     XPenaltyThreshold: 60
+     ZPenaltyThreshold: 60
+     OnePMTScoreThreshold:  0.000001
+     OnePMTXDiffThreshold:  35.;
+     OnePMTPESumThreshold:  500
+     OnePMTPEFracThreshold: 0.3
+    }
+ PhotonLibHypothesis: {
+      GlobalQE: 0.01
+      CCVCorrection: [1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0]
+    }
+ DetectorConfiguration: {
+      # Drift velocity                                                                                                                                                                                  
+      DriftVelocity: 0.1114359 # [cm/us]                                                                                                                                                                
+      # PMT position arrays                            
+       X: [-11.6415,-11.8345,-11.4175,-12.1765,-11.4545,-11.7755,-12.0585,-12.5405,-12.6615,-12.3045,-12.6245,-12.6045,-12.6125,-12.8735,-12.9835,-12.6515,-12.6185,-12.6205,-12.5945,-13.1865,-13.4175,-13.0855,-13.1505,-12.6485,-13.0075,-13.3965,-13.5415,-13.4345,-13.4415,-13.1525,-13.2784,-13.2375]
+        Y: [55.313,55.822,27.607,-0.722,-28.625,-56.514,-56.309,55.625,55.8,-0.502,-0.051,-56.284,-56.408,55.822,55.771,-0.549,-0.875,-56.205,-56.323,54.693,54.646,-0.706,-0.829,-57.022,-56.261,55.249,55.249,27.431,-0.303,-28.576,-56.203,-56.615]
+        Z: [951.862,911.065,989.711,865.599,990.356,951.865,911.94,751.883,711.073,796.208,664.203,751.906,711.274,540.93,500.134,585.284,453.095,540.617,500.22,328.212,287.977,373.839,242.014,328.341,287.639,128.355,87.7605,51.1015,173.743,50.4745,128.18,87.8695]
+      }
+      ActiveVolume: {
+        X: [0.0,256.35]
+        Y: [-116.5,116.5]
+        Z: [0.0,1036.8]
+        }
+    }
 }

--- a/app/ThruMu/BoundaryMuonTaggerAlgo.cxx
+++ b/app/ThruMu/BoundaryMuonTaggerAlgo.cxx
@@ -177,7 +177,7 @@ namespace larlitecv {
 //   int BoundaryMuonTaggerAlgo::makeTrackClusters3D( const std::vector<larcv::Image2D>& img_v, const std::vector<larcv::Image2D>& badchimg_v,
 //                                                    const std::vector< const BoundarySpacePoint* >& spacepts,
 //                                                    std::vector< larlitecv::BMTrackCluster3D >& trackclusters, 
-//                                                    std::vector< larcv::Image2D >& tagged_v, std::vector<int>& used_endpoints_indices) {
+//                                                    std::vector< larcv::Image2D >& tagged_v, std::vector<int>& used_endpoints_indices, const std::vector <larlite::event_opflash>& opflash_v ) {
 //     // This method takes in the list of boundaryspacepoints and pairs them up in order to try to find through-going muons
 //     int nendpts = (int)spacepts.size();
 //     used_endpoints_indices.resize( nendpts, 0 );

--- a/app/ThruMu/FlashMuonTaggerAlgo.cxx
+++ b/app/ThruMu/FlashMuonTaggerAlgo.cxx
@@ -20,11 +20,17 @@
 #include "Linear3DChargeTagger.h"
 
 namespace larlitecv {
-    
+
+  // Added a new vector: endpoint_flash_producer_idx.  This is '0' if it corresponds to 'simpleFlashBeam' and 1 if it corresponds to 'simpleFlashCosmic'.
   bool FlashMuonTaggerAlgo::flashMatchTrackEnds( const std::vector< larlite::event_opflash* >& opflashsets, 
                                                  const std::vector<larcv::Image2D>& tpc_imgs,
                                                  const std::vector<larcv::Image2D>& badch_imgs,
-                                                 std::vector< BoundarySpacePoint >& trackendpts ) {
+                                                 std::vector< BoundarySpacePoint >& trackendpts,
+						 std::vector< int >& endpoint_flash_idx, std::vector< int >& endpoint_flash_producer_idx ) {
+
+    // Print out the size of 'trackendpts', which should be nonzero because the side tagger algo has already operated.
+    std::cout << "Length of 'trackendpts' at the start of the 'flashMatchTrackEnds' function." << std::endl;
+    
     // output
     // ------
     //  trackendpts: list of vector of end pts. each (inner vector) is point on each plane.
@@ -45,10 +51,18 @@ namespace larlitecv {
     
     // get a meta
     const larcv::ImageMeta& meta = tpc_imgs.at(0).meta();
+
+    // Declare a variable for the flash producer being used.
+    // BIG DISCLAIMER: This variable assumes that the first flash looped over is 'simpleFlashBeam' and the second is 'simpleFlashCosmic'.  That's the way things have been oriented in every config file that I've seen, but that is the orientation that I am using here.
+
+    int opflash_producer_idx = 0;
     
     // loop over all the flash containers
     for ( auto& ptr_event_flash : opflashsets ) {
       // loop over flashes
+
+      int opflash_idx = 0;
+      
       for ( auto& opflash : *ptr_event_flash ) {
         
         // determine time of flash
@@ -165,12 +179,19 @@ namespace larlitecv {
 	// Flash search method: we use the charge clusters at a given time
 	if ( fConfig.endpoint_clustering_algo=="cluster" )
 	  FindFlashesByChargeClusters( row_target, point_type, tpc_imgs, badch_imgs, z_range, y_range, trackendpts );
-	else if ( fConfig.endpoint_clustering_algo=="segment" )
-	  FindFlashesBy3DSegments( row_target, point_type, tpc_imgs, badch_imgs, z_max, z_range, trackendpts );
+	else if ( fConfig.endpoint_clustering_algo=="segment" ) // This is the one that we will be using.
+	  FindFlashesBy3DSegments( row_target, point_type, tpc_imgs, badch_imgs, z_max, z_range, trackendpts, endpoint_flash_idx, opflash_idx, endpoint_flash_producer_idx, opflash_producer_idx );
 	else
 	  throw std::runtime_error("FlashMuonTaggerAlgo:: end point clustering strategy not recognized. options: \"cluster\" or \"segment\"");
 
+	// increment 'opflash_idx'
+	opflash_idx += 1;
+
       }//end of opflashes loop
+
+      // Increment 'opflash_producer_idx'.
+      opflash_producer_idx += 1;
+      
     }//end of opflashsets
 
     return true;
@@ -743,8 +764,9 @@ namespace larlitecv {
 
   }// end of function
 
+  // Pass all of the parameters with the endpoint information as well: 'endpoint_flash_idx' and 'endpoint_flash_producer_idx'.
   bool FlashMuonTaggerAlgo::findImageTrackEnds( const std::vector<larcv::Image2D>& tpc_imgs, const std::vector<larcv::Image2D>& badch_imgs,
-                                                std::vector<BoundarySpacePoint >& trackendpts ) {
+                                                std::vector<BoundarySpacePoint >& trackendpts, std::vector < int >& endpoint_flash_idx, std::vector< int >& endpoint_flash_producer_idx ) {
     
     if ( fSearchMode!=kOutOfImage ) {
       std::cout << "[ERROR] Invalid search mode for these type of track endpoints" << std::endl;
@@ -761,7 +783,7 @@ namespace larlitecv {
     std::vector< larlite::event_opflash* > faux_flash_front_v;    
     faux_flash_front_v.push_back( faux_flash_front );
     fOutOfImageMode = kFront;
-    bool results = flashMatchTrackEnds( faux_flash_front_v, tpc_imgs, badch_imgs, trackendpts );
+    bool results = flashMatchTrackEnds( faux_flash_front_v, tpc_imgs, badch_imgs, trackendpts, endpoint_flash_idx, endpoint_flash_producer_idx );
 
     larlite::event_opflash* faux_flash_back = new larlite::event_opflash;        
     larlite::opflash img_end( 2400.0+6048-60.0, 0, 0, 0, dummy ); // make this config pars
@@ -769,7 +791,7 @@ namespace larlitecv {
     std::vector< larlite::event_opflash* > faux_flash_back_v;    
     faux_flash_back_v.push_back( faux_flash_back );
     fOutOfImageMode = kBack;
-    results = flashMatchTrackEnds( faux_flash_back_v, tpc_imgs, badch_imgs, trackendpts );
+    results = flashMatchTrackEnds( faux_flash_back_v, tpc_imgs, badch_imgs, trackendpts, endpoint_flash_idx, endpoint_flash_producer_idx );
 
     delete faux_flash_back;
     delete faux_flash_front;
@@ -867,7 +889,15 @@ namespace larlitecv {
 
   void FlashMuonTaggerAlgo::FindFlashesBy3DSegments( const int row_target, const larlitecv::BoundaryEnd_t point_type,
 						     const std::vector<larcv::Image2D>& tpc_imgs, const std::vector<larcv::Image2D>& badch_imgs,
-						     const float z_max, const std::vector<float>& z_range, std::vector< BoundarySpacePoint >& trackendpts ) {
+						     const float z_max, const std::vector<float>& z_range, std::vector< BoundarySpacePoint >& trackendpts, std::vector < int >& endpoint_flash_idx, int& opflash_idx, std::vector< int >& endpoint_flash_producer_idx, int& opflash_producer_idx) {
+
+    // Declare a new variable.  This will be used to tell which type of flash that we've found on the boundary.
+    // Code for this variable:
+    // Anode:     1
+    // Cathode:   2
+    // Image End: 3 
+    int type_of_endpoint_found = 0;
+
     const int row_gap_size = 6;
     Segment3DAlgo segalgo;
     segalgo.setVerbosity( fConfig.verbosity );
@@ -981,6 +1011,17 @@ namespace larlitecv {
       
       
       if ( pos_matches && !inmiddle ) {
+
+	if ( point_type == larlitecv::kAnode )
+	  type_of_endpoint_found = 1;
+	if ( point_type == larlitecv::kCathode )
+	  type_of_endpoint_found = 2;
+	if (point_type == larlitecv::kImageEnd )
+	  type_of_endpoint_found = 3;
+      
+	// Print Statement
+	std::cout << "Making a boundary endpoint of type (CRB statement): " << type_of_endpoint_found << "." << std::endl;
+	
 	//make the boundary spacepoint object
 	std::vector< larlitecv::BoundaryEndPt > endpt_v;
 	for (size_t p=0; p<tpc_imgs.size(); p++) {
@@ -1002,7 +1043,12 @@ namespace larlitecv {
     if ( (int)candidate_endpts.size()<=fConfig.max_nsegments_per_flash || point_type==larlitecv::kImageEnd ) {
       // If under the max, pass them on
       for ( auto& sp : candidate_endpts ) {
+	std::cout << "Appending candidate endpoints." << std::endl;
 	trackendpts.emplace_back(std::move(sp));
+
+	// Append the track endpoint coordinate information.
+	endpoint_flash_idx.emplace_back( opflash_idx );
+	endpoint_flash_producer_idx.emplace_back( opflash_producer_idx );
       }
     }
     else {
@@ -1045,6 +1091,9 @@ namespace larlitecv {
 
       std::sort( qlist.begin(), qlist.end() );
 
+      // Silly statement to see if this loop gets entered.
+      std::cout << "Sugar plum fairies!! " << std::endl;
+      
       if ( point_type==larlitecv::kAnode ) {
 	// if crossing the anode, we should be close to the max
 	if ( fConfig.verbosity>1 )	
@@ -1053,6 +1102,10 @@ namespace larlitecv {
 	  if ( fConfig.verbosity>1 )	  
 	    std::cout << "  idx=" << qlist[i].idx << " dist=" << qlist[i].z_dist << " zpos=" << candidate_endpts[ qlist[i].idx ].pos()[2] << std::endl;
 	  trackendpts.emplace_back( std::move( candidate_endpts[ qlist[i].idx ] ) );
+
+	  // Append the information for the track endpoints.
+	  endpoint_flash_idx.push_back(opflash_idx);
+	  endpoint_flash_producer_idx.emplace_back( opflash_producer_idx );
 	}
       }
       else {
@@ -1063,6 +1116,10 @@ namespace larlitecv {
 	  if ( fConfig.verbosity>1 )
 	    std::cout << "  idx=" << qlist[i].idx << " dist=" << qlist[i].z_dist << " zpos=" << candidate_endpts[ qlist[i].idx ].pos()[2] << std::endl;	  
 	  trackendpts.emplace_back( std::move( candidate_endpts[ qlist[i].idx ] ) );
+
+	  // Append the information for the track endpoints.
+	  endpoint_flash_idx.push_back(opflash_idx);
+	  endpoint_flash_producer_idx.emplace_back( opflash_producer_idx );
 	}	
       }
     }
@@ -1070,4 +1127,5 @@ namespace larlitecv {
   }
   
 }
+
 

--- a/app/ThruMu/FlashMuonTaggerAlgo.h
+++ b/app/ThruMu/FlashMuonTaggerAlgo.h
@@ -59,10 +59,10 @@ namespace larlitecv {
 
     bool flashMatchTrackEnds( const std::vector< larlite::event_opflash* >& opflashsets, const std::vector<larcv::Image2D>& tpc_imgs,
 			      const std::vector<larcv::Image2D>& badch_imgs,
-			      std::vector< BoundarySpacePoint >& trackendpts );
+			      std::vector< BoundarySpacePoint >& trackendpts, std::vector< int >& endpoint_flash_idx, std::vector< int >& endpoint_flash_producer_idx ); // The last two arguments were added to find out which flash is matched to which endpoint.
 
     bool findImageTrackEnds( const std::vector<larcv::Image2D>& tpc_imgs, const std::vector<larcv::Image2D>& badch_imgs,
-			     std::vector< BoundarySpacePoint >& trackendpts );
+			     std::vector< BoundarySpacePoint >& trackendpts, std::vector < int >& endpoint_flash_idx, std::vector< int >& endpoint_flash_producer_idx ); // The last two arguments were added to find out which flash is matched to which endpoint.
 
     BoundaryEnd_t SearchModeToEndType( SearchMode_t mode );
     
@@ -111,7 +111,7 @@ namespace larlitecv {
 
     void FindFlashesBy3DSegments( const int row_target, const larlitecv::BoundaryEnd_t point_type,
 				  const std::vector<larcv::Image2D>& tpc_imgs, const std::vector<larcv::Image2D>& badch_imgs,
-				  const float z_max, const std::vector<float>& z_range, std::vector< BoundarySpacePoint >& trackendpts );
+				  const float z_max, const std::vector<float>& z_range, std::vector< BoundarySpacePoint >& trackendpts, std::vector < int >& endpoint_flash_idx, int& opflash_idx, std::vector< int >& endpoint_flash_producer_idx, int& opflash_producer_idx );
     
     
 

--- a/app/ThruMu/GNUmakefile
+++ b/app/ThruMu/GNUmakefile
@@ -16,6 +16,8 @@ INCFLAGS += $(shell larlite-config --includes)
 INCFLAGS += $(shell larcv-config --includes) 
 INCFLAGS += -I$(LARLITE_BASEDIR)/UserDev
 INCFLAGS += -I$(LARLITE_BASEDIR)/UserDev/BasicTool
+INCFLAGS += -I$(LARLITE_BASEDIR)/UserDev/SelectionTool # Added this for the OpT0Finder infrastructure.
+INCFLAGS += -I$(LARLITE_COREDIR) # Added this for the 'DataFormat' section.
 INCFLAGS += -I$(LARLITECV_BASEDIR)/app
 INCFLAGS += $(shell larlitecv-config --includes)
 INCFLAGS += -I$(LARCV_BASEDIR)/app/ann_1.1.2/include
@@ -28,7 +30,7 @@ OSNAMEMODE      = $(OSNAME)
 include $(LARLITECV_BASEDIR)/Makefile/Makefile.${OSNAME}
 
 LDFLAGS += $(shell larcv-config --libs)
-LDFLAGS += $(shell larlite-config --libs) -lBasicTool_GeoAlgo
+LDFLAGS += $(shell larlite-config --libs) -lBasicTool_GeoAlgo -lSelectionTool_OpT0FinderBase -lSelectionTool_OpT0FinderAlgorithms # Added the last two for the SelectionTool infrastructure.
 # call the common GNUmakefile
 include $(LARLITECV_BASEDIR)/Makefile/GNUmakefile.CORE
 

--- a/app/ThruMu/ThruMuTracker.h
+++ b/app/ThruMu/ThruMuTracker.h
@@ -16,11 +16,16 @@
 // larcv
 #include "DataFormat/Image2D.h"
 
+// larlite
+#include "DataFormat/opflash.h"
+
 // larlitecv
 #include "TaggerTypes/BoundarySpacePoint.h"
 #include "TaggerTypes/BMTrackCluster3D.h"
 #include "ThruMuTrackerConfig.h"
 #include "Linear3DChargeTagger.h"
+#include "GeneralFlashMatchAlgo/GeneralFlashMatchAlgoConfig.h"
+#include "GeneralFlashMatchAlgo/GeneralFlashMatchAlgo.h"
 
 namespace larlitecv {
 
@@ -31,11 +36,16 @@ namespace larlitecv {
     ThruMuTracker( const ThruMuTrackerConfig& config );
     virtual ~ThruMuTracker() {};
 
+    // Add an argument onto the start of the function:
+    // 'flash_config' - this is the set of configuration parameters for the 'GeneralFlashMatchAlgo' class, of type 'GeneralFlashMatchAlgoConfig'.
 
-    void makeTrackClusters3D( const std::vector<larcv::Image2D>& img_v, const std::vector<larcv::Image2D>& badchimg_v,
-			      const std::vector< const BoundarySpacePoint* >& spacepts,
-			      std::vector< larlitecv::BMTrackCluster3D >& trackclusters,
-			      std::vector< larcv::Image2D >& tagged_v, std::vector<int>& used_endpoints_indices);
+    // Add two new arguments onto the end of this function:
+    // flash_idx_v: This is the vector of the indices that correspond to the endpoints contained in the 'spacepts' argument.  Note that this vector (1) assumes that the two flash producers are 'simpleFlashBeam' and 'simpleFlashCosmic' and (2) fills the flash indices in a running, one-dimensional list starting with the flashes produced by 'simpleFlashBeam' before continuing onto the flashes produced by 'simpleFlashCosmic'.
+    void makeTrackClusters3D( GeneralFlashMatchAlgoConfig& flash_config, const std::vector<larcv::Image2D>& img_v, const std::vector<larcv::Image2D>& badchimg_v,
+					     const std::vector< const BoundarySpacePoint* >& spacepts,
+					     std::vector< larlitecv::BMTrackCluster3D >& trackclusters,
+					     std::vector< larcv::Image2D >& tagged_v, std::vector<int>& used_endpoints_indices, const std::vector< larlite::event_opflash* >& opflashsets,
+					     std::vector< int > & flash_idx_v, std::vector< int >& flash_producer_idx_v );
 
   protected:
 
@@ -80,7 +90,8 @@ namespace larlitecv {
 
     void runPass( const int passid, const ThruMuTrackerConfig::ThruMuPassConfig& passcfg, const std::vector< const BoundarySpacePoint* >& spacepts,
 		  const std::vector<larcv::Image2D>& img_v, const std::vector<larcv::Image2D>& badchimg_v, std::vector<larcv::Image2D>& tagged_v,
-		  std::vector<int>& used_endpoints_indices, std::vector<larlitecv::BMTrackCluster3D>& trackclusters );
+		  std::vector<int>& used_endpoints_indices, std::vector<larlitecv::BMTrackCluster3D>& trackclusters, const std::vector< int >& flash_idx_v,
+                               const std::vector< int >& flash_producer_idx_v, std::vector< int > track_endpoint_flash_idx_v, std::vector< int > track_endpoint_flash_producer_idx_v );
 
     larlitecv::BMTrackCluster3D runLinearChargeTagger( const ThruMuTrackerConfig::ThruMuPassConfig& pass_cfg,
                     const BoundarySpacePoint& pts_a, const BoundarySpacePoint& pts_b,
@@ -95,6 +106,12 @@ namespace larlitecv {
     void runFoxTrotExtender( const ThruMuTrackerConfig::ThruMuPassConfig& pass_cfg, std::vector<std::vector<double> >& track,
                   const std::vector<larcv::Image2D>& img_v, const std::vector<larcv::Image2D>& badch_v, const std::vector<larcv::Image2D>& tagged_v,
                   ThruMuTracker::FoxTrotExtenderInfo& result_info );
+
+    // Add the new function for flash-matching the tracks in the ThruMu stage of reconstruction.
+    void flashMatchTracks( GeneralFlashMatchAlgoConfig& flash_config, const std::vector<larcv::Image2D>& img_v, const std::vector<larcv::Image2D>& tagged_v, 
+			   const std::vector< const BoundarySpacePoint* >& spacepts, const std::vector< larlite::event_opflash* >& opflash_v, std::vector< BMTrackCluster3D >& trackclusters, 
+			   std::vector< int >& impossible_match_endpoints, std::vector< int >& already_matched_flash_idx, const int& num_of_tracks_added_in_pass, 
+			   std::vector< int >& track_endpoint_flash_idx_v, std::vector< int >& track_endpoint_flash_producer_idx_v );
 
 
     // for astar, compressed image containers

--- a/app/ThruMu/ThruMuTrackerConfig.cxx
+++ b/app/ThruMu/ThruMuTrackerConfig.cxx
@@ -17,6 +17,7 @@ namespace larlitecv {
     pixel_threshold.resize(3,10);
     compression_mode = 2;
     downsampling_factor = 4;
+    thrumu_flashmatch = true;
 
     // setup example pass config
     ThruMuPassConfig passcfg;
@@ -80,6 +81,7 @@ namespace larlitecv {
     cfg.pixel_threshold  = pset.get< std::vector<float> >("PixelThresholds");
     cfg.downsampling_factor = pset.get<int>("DownsampleFactor");
     cfg.compression_mode = pset.get<int>("CompressionMode");
+    cfg.thrumu_flashmatch = pset.get<bool>("ThruMuFlashMatch");
     cfg.pass_configs.clear();
     for ( int ipass=0; ipass<cfg.num_passes; ipass++ ) {
       std::stringstream ss;

--- a/app/ThruMu/ThruMuTrackerConfig.h
+++ b/app/ThruMu/ThruMuTrackerConfig.h
@@ -56,6 +56,7 @@ namespace larlitecv {
     int num_passes; //< number of passes
     int compression_mode; //< downsampling method to use for astar (see larcv::Image2D for enum definition)
     int downsampling_factor; //< downsampling factor
+    bool thrumu_flashmatch;
     std::vector<int> tag_neighborhood;
     std::vector<float> pixel_threshold;
     std::vector< ThruMuPassConfig > pass_configs; //< configuration for each pass

--- a/app/ThruMu/bin/thrumu.cxx
+++ b/app/ThruMu/bin/thrumu.cxx
@@ -284,7 +284,7 @@ int main( int nargs, char** argv ) {
     std::vector< larlitecv::BMTrackCluster3D > tracks3d;
     std::vector< int > used_filtered_endpoints( filtered_endpoints.size(), 0 );
     if (runtracker) {
-      sidetagger.makeTrackClusters3D( imgs, gapchimgs_v, filtered_endpoints, tracks3d, tagged_v, used_filtered_endpoints );
+      sidetagger.makeTrackClusters3D( imgs, gapchimgs_v, filtered_endpoints, tracks3d, tagged_v, used_filtered_endpoints, opflash_containers );
     }
 
     // ------------------------------------------------------------------------------------------//


### PR DESCRIPTION
/home/barnchri/Clean_Tagger_for_Flash_Match_Integration/dllee_unified/larlitecv/build/lib/liblarlitecv.so: undefined reference to `larlitecv::GeneralFlashMatchAlgo::generate_single_opflash_vector_for_event(std::vector<larlite::event_opflash*, std::allocator<larlite::event_opflash*> >)'
/home/barnchri/Clean_Tagger_for_Flash_Match_Integration/dllee_unified/larlitecv/build/lib/liblarlitecv.so: undefined reference to `larlitecv::GeneralFlashMatchAlgo::generate_chi2_in_track_flash_comparison(flashana::QCluster_t, larlite::opflash, int)'
/home/barnchri/Clean_Tagger_for_Flash_Match_Integration/dllee_unified/larlitecv/build/lib/liblarlitecv.so: undefined reference to `larlitecv::GeneralFlashMatchAlgo::ExpandQClusterStartingWithLarliteTrack(flashana::QCluster_t, larlite::track const&, double, bool, bool)'
collect2: error: ld returned 1 exit status
make[1]: *** [run_tagger] Error 1
make[1]: Leaving directory `/home/barnchri/Clean_Tagger_for_Flash_Match_Integration/dllee_unified/larlitecv/app/TaggerCROI/bin'
make: *** [bin] Error 2

^ This error comes from the 'run_tagger.cxx' executable in the 'larlitecv/app/TaggerCROI/bin' directory.  The GNUmakefile has to be modified somehow.