### PR TITLE
shower reco processor compatibility

### DIFF
--- a/core/Base/DataCoordinator.cxx
+++ b/core/Base/DataCoordinator.cxx
@@ -118,6 +118,7 @@ namespace larlitecv {
     if ( !larlite_unused ) {
       for ( auto const &larlitefile : fManagers["larlite"]->get_final_filelist() )
 	larlite_io.add_in_filename( larlitefile );
+      
       larlite_io.open();
       larlite_io.enable_event_alignment(false);
     }
@@ -144,10 +145,7 @@ namespace larlitecv {
   }
   
   void DataCoordinator::finalize() {
-    if ( !larlite_unused ) {
-      //larlite_io.next_event();
-      larlite_io.close();
-    }
+    if ( !larlite_unused ) larlite_io.close();
     if ( !larcv_unused )   larcv_io.finalize();
   }
   
@@ -215,11 +213,14 @@ namespace larlitecv {
 
     std::string outfilename = pset.get<std::string>( "OutFileName", "" );
     if ( iomode==1 || iomode==2 ) {
-      if ( outfilename=="" ) {
-	std::cout << "Larlite file is set to write mode, but does not have an output file name." << std::endl;
-	assert(false);
+      if (ioman.output_filename().empty()) {
+	if ( outfilename.empty()) {
+	  std::cout << "Larlite file is set to write mode, but does not have an output file name." << std::endl;
+	  assert(false);
+	}
+	ioman.set_out_filename( outfilename );
+	assert(!ioman.output_filename().empty());
       }
-      ioman.set_out_filename( outfilename );
     }
 
     // specified read/write datatypes

--- a/core/Base/LarcvFileManager.cxx
+++ b/core/Base/LarcvFileManager.cxx
@@ -63,7 +63,9 @@ namespace larlitecv {
          size_t found1 = keyname.find("_");
          std::string dtype    = keyname.substr(0,found1);
          std::string producer = keyname.substr(found1+1,foundlast-found1-1 );
-         if ( (!found_id_tree && dtype=="image2d") or (found_id_tree && dtype=="partroi" ) ) {
+         if ( (!found_id_tree && dtype=="image2d") or 
+	      (!found_id_tree && dtype=="partroi") or
+	      (!found_id_tree && dtype=="pgraph" ) ) {
           found_id_tree = true;
           idtreename = keyname;
           idtreetype = dtype;
@@ -75,8 +77,9 @@ namespace larlitecv {
         trees.insert( keyname );
       }
       
-      if ( !found_id_tree )
+      if ( !found_id_tree ) {
         continue; // skip this file, we won't know how to index it.
+      }
 
       // make a hash out of the name of tree is the file. will be used to define the flavor of this file
       std::string treehashname = ":";
@@ -105,8 +108,8 @@ namespace larlitecv {
         product_ptr = (larcv::EventBase*)(larcv::DataProductFactory::get().create(larcv::kProductImage2D,idtreeproducer));
       else if ( idtreetype=="partroi" ) 
         product_ptr = (larcv::EventBase*)(larcv::DataProductFactory::get().create(larcv::kProductROI,idtreeproducer));
-      else if ( idtreetype=="pixel2d" ) 
-        product_ptr = (larcv::EventBase*)(larcv::DataProductFactory::get().create(larcv::kProductROI,idtreeproducer));
+      else if ( idtreetype=="pgraph" ) 
+        product_ptr = (larcv::EventBase*)(larcv::DataProductFactory::get().create(larcv::kProductPGraph,idtreeproducer));
       else {
         throw std::runtime_error( "could not find a LArCV tree to build an index with." );
       }

--- a/core/Hashlib2plus/LinkDef.h
+++ b/core/Hashlib2plus/LinkDef.h
@@ -1,18 +1,23 @@
-//
-// cint script to generate libraries
-// Declaire namespace & classes you defined
-// #pragma statement: order matters! Google it ;)
-//
-
 #ifdef __CINT__
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 
-// Classes
-//ADD_NEW_CLASS ... do not change this line
+#pragma link C++ class hlException+;
+#pragma link C++ class hashwrapper+;
+#pragma link C++ class MD5+;
+#pragma link C++ class md5wrapper+;
+#pragma link C++ class SHA1+;
+#pragma link C++ class sha1wrapper+;
+#pragma link C++ class SHA256+;
+#pragma link C++ class sha256wrapper+;
+#pragma link C++ class SHA2ext+;
+#pragma link C++ class sha384wrapper+;
+#pragma link C++ class sha512wrapper+;
+#pragma link C++ class wrapperfactory+;
 
 #endif
+
 
 
 


### PR DESCRIPTION
minor updates to...
*) `LarcvFileManager.cxx`  -- allow dtype=pgraph larcv producer to be the larcv found_id_tree.
*) `Linkdef.h` -- hash2lib classes exported.
*) `DataCoordinator` -- allow setting of larlite output file name outside of text configure file & handle case where output file name is set by by the user (via `DataCoordinator::get_larlite_io().set_out_filename(...)` or otherwise) in `DataCoordinator::do_larlite_config(...)`.